### PR TITLE
gem update --systemをする前にrubygemsのHTTPソースを有効に、SSL接続を要求するソースを無効にしておく

### DIFF
--- a/setup.rb
+++ b/setup.rb
@@ -75,9 +75,20 @@ def create_shortcut!()
   shortcut.Save
 end
 
+def temporary_disable_ssl_source!()
+  system("gem source -r https://rubugems.org")
+  system("gem source -a http://rubygems.org")
+end
+
+def reenable_ssl_source!()
+  system("gem source -r http://rubugems.org")
+  system("gem source -a https://rubygems.org")
+end
 
 def bundle!()
+  temporary_disable_ssl_source!
   system("gem update --system")
+  reenable_ssl_source!
   system("gem install bundler")
 
   Dir.chdir($mikutter_dir)


### PR DESCRIPTION
SSLの認証ができない問題を一時的に回避します。
gemのWindows向けの機能には今現在バグがあり、
Ruby 2.1.5よりも新しいRubyをインストールできるRuby Installerが
リリースされていないためこの回避策を入れました。

Ruby 2.2系がインストールできるRuby Installer、もしくはこの問題に対応された
gemが同梱されたRuby Installer がリリースされた場合は、
このコミットをrevertするか、SSLソースを一時的に使わないようにしている箇所を
削除してください。