### PR TITLE
GdkPixbuf　3.0.9で変更されたメソッド名の有無を確認してからaliasするようにしました

### DIFF
--- a/450_gdk_pixbuf_3_0_9_function_name_fix.rb
+++ b/450_gdk_pixbuf_3_0_9_function_name_fix.rb
@@ -1,8 +1,17 @@
 # GdkPixbuf 3.0.9でいくつかのメソッドの名前が変わってるのを修正
 module GdkPixbuf
   class Pixbuf
-    alias :initialize_new_from_file_at_size :initialize_new_from_file_at_size_utf8
-    alias :initialize_new_from_file_at_scale :initialize_new_from_file_at_scale_utf8
-    alias :initialize_new_from_file :initialize_new_from_file_utf8
+    if private_method_defined?(:initialize_new_from_file_utf8)
+      alias_method :initialize_new_from_file,
+                   :initialize_new_from_file_utf8
+    end
+    if private_method_defined?(:initialize_new_from_file_at_size_utf8)
+      alias_method :initialize_new_from_file_at_size,
+                   :initialize_new_from_file_at_size_utf8
+    end
+    if private_method_defined?(:initialize_new_from_file_at_scale_utf8)
+      alias_method :initialize_new_from_file_at_scale,
+                   :initialize_new_from_file_at_scale_utf8
+    end
   end
 end


### PR DESCRIPTION
mikutter hotfix/3.4 ブランチの最新で gtk2 gem のバージョンが 3.0.8 に差し戻されていたので、3.0.8 以前でも動くように alias_method する前にメソッドの存在チェックを行うようにしました